### PR TITLE
#908 Fix: InsufficientLevelException (#911)

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
+++ b/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
@@ -212,8 +212,13 @@ public class PlayerProfile {
 	 */
 	public PlayerLevelUpRewards acceptLevelUpRewards(int level)
 			throws RequestFailedException {
+		return this.acceptLevelUpRewards(level, true);
+	}
+
+	private PlayerLevelUpRewards acceptLevelUpRewards(int level, boolean checkLevel)
+			throws RequestFailedException {
 		// Check if we even have achieved this level yet
-		if (level > stats.getLevel()) {
+		if (checkLevel && level > stats.getLevel()) {
 			throw new InsufficientLevelException();
 		}
 		LevelUpRewardsMessage msg = LevelUpRewardsMessage.newBuilder()
@@ -383,7 +388,7 @@ public class PlayerProfile {
 				for (PlayerListener listener : listeners) {
 					listener.onLevelUp(api, level, newLevel);
 				}
-				acceptLevelUpRewards(newLevel);
+				acceptLevelUpRewards(newLevel, false);
 			}
 		}
 		this.stats = stats;


### PR DESCRIPTION
* #908 Fix: InsufficientLevelException

The proposed fix makes a private method w/ a boolean to determine if the consistency check for level has to be performed.
The public acceptLevelUpRewards() calls it w/ checkLevel=true.
The setStats() method used the private one w/ checkLevel=false.
This keeps the logic of setStats unaltered (as I didn't know the reasoning behind it).

* Fix: missing return statement.

### Prerequisites (Remove this section if you want)
Make sure you...

* Follow the [contribution guidelines](CONTRIBUTING.md)
* Follow the code style (run `./gradlew checkstyleMain`)
* Submit this PR against the `Development` branch.

**Fixed issue:** [Reference the issue number here, or remove if not a fix]

**Changes made:**

* List your changes here
* Change 2...